### PR TITLE
Avatar image transform

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -1,0 +1,3 @@
+{
+  "ALLOWED_ORIGIN": "*"
+}

--- a/config/prod.json
+++ b/config/prod.json
@@ -1,0 +1,3 @@
+{
+  "ALLOWED_ORIGIN": "https://journaly.com"
+}

--- a/config/stage.json
+++ b/config/stage.json
@@ -1,0 +1,3 @@
+{
+  "ALLOWED_ORIGIN": "https://*.journaly.vercel.app"
+}

--- a/handler.ts
+++ b/handler.ts
@@ -1,37 +1,75 @@
 import AWS from 'aws-sdk'
-import sharp from 'sharp'
+import sharp, { Sharp } from 'sharp'
 import { S3Handler } from 'aws-lambda'
 
 const s3 = new AWS.S3()
 
-export const handleUpload: S3Handler = async (event, contex) => {
-  for (let i=0; i<event.Records.length; i++) {
-    const rec = event.Records[i]
-    const inputImage = await s3.getObject({
-      Bucket: rec.s3.bucket.name,
-      Key: rec.s3.object.key,
-    }).promise()
-
-    const input = sharp(inputImage.Body)
-
-    const t = async (size: number, suffix: string) => {
-      const transformed = await input.clone()
-        .resize(size, null, { withoutEnlargement: true })
-        .jpeg({ quality: 90 })
-        .toBuffer()
-
-      return s3.putObject({
-        Bucket: process.env.TRANSFORM_BUCKET!,
-        Key: `${rec.s3.object.key}-${suffix}`,
-        Body: transformed,
-        ContentType: 'image/jpeg',
-        StorageClass: 'INTELLIGENT_TIERING',
-      }).promise()
-    }
-
-    await Promise.all([
-      t(1200, 'large'),
-      t(400, 'small'),
-    ])
-  }
+type TransformDefinition = {
+  name: string
+  transform: (input: Sharp) => Promise<Buffer>
 }
+
+type HandlerDefinition = {
+  transforms: TransformDefinition[],
+}
+
+
+const createHandler = (handlerDef: HandlerDefinition) => {
+  const handler: S3Handler = async (event, contex) => {
+    for (let i=0; i<event.Records.length; i++) {
+      const rec = event.Records[i]
+      const inputImage = await s3.getObject({
+        Bucket: rec.s3.bucket.name,
+        Key: rec.s3.object.key,
+      }).promise()
+
+      const input = sharp(inputImage.Body)
+
+      await Promise.all(handlerDef.transforms.map(async ({ name, transform }) => {
+        const transformed = await transform(input.clone())
+
+        return s3.putObject({
+          Bucket: process.env.TRANSFORM_BUCKET!,
+          Key: `${rec.s3.object.key}-${name}`,
+          Body: transformed,
+          ContentType: 'image/jpeg',
+          StorageClass: 'INTELLIGENT_TIERING',
+        }).promise()
+
+      }))
+    }
+  }
+
+  return handler
+}
+
+export const handlePostImage = createHandler({
+  transforms: [
+    {
+      name: 'large',
+      transform: (input) => (input
+        .resize(1200, null, { withoutEnlargement: true })
+        .jpeg({ quality: 90 })
+        .toBuffer())
+    },
+    {
+      name: 'small',
+      transform: (input) => (input
+        .resize(400, null, { withoutEnlargement: true })
+        .jpeg({ quality: 90 })
+        .toBuffer())
+    },
+  ]
+})
+
+export const handleAvatarImage = createHandler({
+  transforms: [
+    {
+      name: 'large',
+      transform: (input) => (input
+        .resize(150, 150, { fit: 'cover' })
+        .jpeg({ quality: 90 })
+        .toBuffer())
+    },
+  ]
+})

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Nail those thumbs!",
   "main": "index.js",
   "scripts": {
+    "type-check": "tsc",
+    "deploy:dev": "sls deploy --stage dev",
     "deploy:stage": "sls deploy --stage stage",
     "deploy:prod": "sls deploy --stage prod"
   },

--- a/serverless.yml
+++ b/serverless.yml
@@ -35,13 +35,25 @@ provider:
             - "*"
 
 functions:
-  upload:
-    handler: handler.handleUpload
+  uploadPostImage:
+    handler: handler.handlePostImage
     events:
       - s3:
           bucket: ${self:custom.uploadBucketName}
           event: s3:ObjectCreated:*
           existing: true
+          rules:
+            - prefix: post-image/
+
+  uploadAvatarImage:
+    handler: handler.handleAvatarImage
+    events:
+      - s3:
+          bucket: ${self:custom.uploadBucketName}
+          event: s3:ObjectCreated:*
+          existing: true
+          rules:
+            - prefix: avatar-image/
 
 resources:
   Resources:

--- a/serverless.yml
+++ b/serverless.yml
@@ -54,7 +54,7 @@ resources:
             - AllowedMethods:
                 - PUT
               AllowedOrigins:
-                - '*'
+                - ${file(./config/${opt:stage, 'dev'}.json):ALLOWED_ORIGIN}
               AllowedHeaders:
                 - '*'
         


### PR DESCRIPTION
Adds support for multiple transform configurations, our second configuration is for avatar images. Previously we were reusing the post image config so we'd get a 1200px by something image which was wayyyy bigger than we'd ever present to the user. Now avatar uploads are 150px square. This should reduce the total network IO required to load the feed and comments, plus save us a little on S3 costs. Main goal here however is a PoC for multiple image transforms which will be necessary for inline images.